### PR TITLE
Endpoint to get patients by population in measure

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -97,6 +97,50 @@ paths:
             was not found
         500:
           description: Internal Server Error
+  /QualityReport/{id}/PatientResults:
+    get:
+      operationId: getQualityReportPatientResults
+      summary: |
+        Get a list of patients for a given population. Patients are sorted by last name.
+      tags:
+        - QualityReport
+      parameters:
+        - name: id
+          in: path
+          description: Id for the QualityReport
+          required: true
+          type: string
+        - name: population
+          in: query
+          description: |
+            The desired population. Values are - initialPatientPopulation, denominator, numerator, exception, exclusion, antinumerator
+          required: true
+          type: string
+        - name: limit
+          in: query
+          description: maximum number of patients to return
+          required: true
+          type: string
+          format: int32
+        - name: offset
+          in: query
+          description: number of patients to skip when generating the list
+          required: true
+          type: string
+          format: int32
+      responses:
+        200:
+          description: The desired list of patients for the given population
+          schema:
+            $ref: '#/definitions/PopulationResult'
+        400:
+          description: If the id provided is not a valid BSON ObjectId
+        404:
+          description: |
+            A valid BSON ObjectId was provided but a corresponding QualityReport
+            was not found
+        500:
+          description: Internal Server Error
   /PatientReport/{id}:
     get:
       operationId: getIndividualResult
@@ -254,6 +298,44 @@ definitions:
       measurePopulation:
         type: string
       observation:
+        type: string
+  PopulationResult:
+    description: |
+      A listing of patients that meet a specific population for a Clinical Quality
+      Measure calculation
+    type: object
+    properties:
+      total:
+        type: integer
+        description: The total number of people in the given population that was requested
+      populationQuery:
+        $ref: "#/definitions/PopulationQuery"
+      patients:
+        type: array
+        items:
+          $ref: "#/definitions/IndividualResult"
+  PopulationQuery:
+    description: |
+      A representation of the request to fetch a set of patients for a population of a measure
+    type: object
+    properties:
+      limit:
+        type: integer
+        description: Limit that was provided on the number of patients to return
+      offset:
+        type: integer
+        description: Number of patients to skiped when providing this result.
+      measureId:
+        type: string
+      subId:
+        type: string
+      effectiveDate:
+        type: integer
+        description: |
+          The effectiveDate is the end of the measure period for the purposes of
+          eCQM calculation. It is represented in seconds since January 1, 1970
+          (Unix time).
+      population:
         type: string
   IndividualResult:
     description: |

--- a/api_doc/quality_reports.silk.md
+++ b/api_doc/quality_reports.silk.md
@@ -31,3 +31,16 @@ Get a new quality report
 * Content-Type: application/json; charset=utf-8
 * Data.measureId = "efg"
 * Data.id: "56bd06841cd462774f2af485"
+
+## GET /QualityReport/56bd06841cd462774f2af485/PatientResults?population=initialPatientPopulation
+
+Get all people in the initial patient population for this measure.
+
+* Accept: "application/json"
+
+===
+### Response
+
+* Status: 200
+* Content-Type: application/json; charset=utf-8
+* Data.total = 2

--- a/controllers/quality_reports.go
+++ b/controllers/quality_reports.go
@@ -11,30 +11,37 @@ import (
 	"gopkg.in/validator.v2"
 )
 
+func findQualityReport(db *mgo.Database, c *gin.Context) *models.QualityReport {
+	var id bson.ObjectId
+
+	idString := c.Param("id")
+	if bson.IsObjectIdHex(idString) {
+		id = bson.ObjectIdHex(idString)
+	} else {
+		c.String(http.StatusBadRequest, "Invalid ID")
+		return nil
+	}
+
+	queryCache := db.C("query_cache")
+	qualityReport := &models.QualityReport{}
+	err := queryCache.FindId(id).One(qualityReport)
+	if err != nil {
+		if err == mgo.ErrNotFound {
+			c.String(http.StatusNotFound, "Not found")
+			return nil
+		}
+		c.AbortWithError(http.StatusInternalServerError, err)
+		return nil
+	}
+	return qualityReport
+}
+
 func ShowQualityReportHandler(db *mgo.Database) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		var id bson.ObjectId
-
-		idString := c.Param("id")
-		if bson.IsObjectIdHex(idString) {
-			id = bson.ObjectIdHex(idString)
-		} else {
-			c.String(http.StatusBadRequest, "Invalid ID")
-			return
+		qualityReport := findQualityReport(db, c)
+		if qualityReport != nil {
+			c.JSON(http.StatusOK, qualityReport)
 		}
-
-		queryCache := db.C("query_cache")
-		qualityReport := &models.QualityReport{}
-		err := queryCache.FindId(id).One(qualityReport)
-		if err != nil {
-			if err == mgo.ErrNotFound {
-				c.String(http.StatusNotFound, "Not found")
-				return
-			}
-			c.AbortWithError(http.StatusInternalServerError, err)
-			return
-		}
-		c.JSON(http.StatusOK, qualityReport)
 	}
 }
 
@@ -61,5 +68,49 @@ func CreateQualityReportHandler(db *mgo.Database) gin.HandlerFunc {
 			return
 		}
 		c.JSON(http.StatusOK, qualityReport)
+	}
+}
+
+func ShowQualityReportPatientsHandler(db *mgo.Database) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		populationParam, popPresent := c.GetQuery("population")
+		if !popPresent {
+			c.String(http.StatusBadRequest, "A population must be specified as a query parameter")
+			return
+		}
+		population, err := models.ParsePopulationQuery(populationParam)
+		if err != nil {
+			c.String(http.StatusBadRequest, "Invalid population specified")
+			return
+		}
+		qualityReport := findQualityReport(db, c)
+		if qualityReport != nil {
+			pq := models.PopulationQuery{MeasureID: qualityReport.MeasureID, SubID: qualityReport.SubID,
+				EffectiveDate: qualityReport.EffectiveDate, Population: population}
+			limitParam, limitPresent := c.GetQuery("limit")
+			if limitPresent {
+				limit, err := strconv.ParseInt(limitParam, 10, 32)
+				if err != nil {
+					c.String(http.StatusBadRequest, "Invalid limit specified")
+					return
+				}
+				pq.Limit = int(limit)
+			}
+			offsetParam, offsetPresent := c.GetQuery("offset")
+			if offsetPresent {
+				offset, err := strconv.ParseInt(offsetParam, 10, 32)
+				if err != nil {
+					c.String(http.StatusBadRequest, "Invalid offset specified")
+					return
+				}
+				pq.Offset = int(offset)
+			}
+			pr, err := models.FindResultsForMeasurePopulation(db, pq)
+			if err != nil {
+				c.AbortWithError(http.StatusInternalServerError, err)
+				return
+			}
+			c.JSON(http.StatusOK, pr)
+		}
 	}
 }

--- a/controllers/quality_reports_test.go
+++ b/controllers/quality_reports_test.go
@@ -32,12 +32,25 @@ func (q *QualityReportSuite) SetUpSuite(c *C) {
 	session := q.DBServer.Session()
 	q.Database = session.DB("qme-test")
 	qr := &models.QualityReport{MeasureID: "efg", EffectiveDate: 5678}
-	id := bson.ObjectIdHex("56bd06841cd462774f2af485")
-	qr.ID = id
+	qrID := bson.ObjectIdHex("56bd06841cd462774f2af485")
+	qr.ID = qrID
 	q.Database.C("query_cache").Insert(qr)
+	ir := models.IndividualResult{MeasureID: "abcd", EffectiveDate: 1234, PatientID: "1234", InitialPatientPopulation: 1, Last: "Jones"}
+	id := bson.NewObjectId()
+	rw := &models.ResultWrapper{ID: id, IndividualResult: ir}
+	q.Database.C("patient_cache").Insert(rw)
+	ir2 := models.IndividualResult{MeasureID: "efg", EffectiveDate: 5678, PatientID: "1234", InitialPatientPopulation: 1, Last: "B"}
+	id2 := bson.NewObjectId()
+	rw2 := &models.ResultWrapper{ID: id2, IndividualResult: ir2}
+	q.Database.C("patient_cache").Insert(rw2)
+	ir3 := models.IndividualResult{MeasureID: "efg", EffectiveDate: 5678, PatientID: "5678", InitialPatientPopulation: 1, Denominator: 1, Last: "A"}
+	id3 := bson.NewObjectId()
+	rw3 := &models.ResultWrapper{ID: id3, IndividualResult: ir3}
+	q.Database.C("patient_cache").Insert(rw3)
 	e := gin.New()
 	e.GET("/QualityReport/:id", ShowQualityReportHandler(q.Database))
 	e.POST("/QualityReport", CreateQualityReportHandler(q.Database))
+	e.GET("/QualityReport/:id/PatientResults", ShowQualityReportPatientsHandler(q.Database))
 	q.Engine = e
 }
 

--- a/models/individual_result.go
+++ b/models/individual_result.go
@@ -1,6 +1,9 @@
 package models
 
 import (
+	"errors"
+	"fmt"
+
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 )
@@ -13,7 +16,7 @@ type IndividualResult struct {
 	Gender                   string `bson:"gender,omitempty" json:"gender,omitempty"`
 	InitialPatientPopulation int32  `bson:"IPP" json:"initialPatientPopulation"`
 	Denominator              int32  `bson:"DENOM,omitempty" json:"denominator"`
-	Exception                int32  `bson:"DENEXCP,omitempty" json:"exception"`
+	Exception                int32  `bson:"DENEXCEP,omitempty" json:"exception"`
 	Exclusion                int32  `bson:"DENEX,omitempty" json:"exclusion"`
 	Numerator                int32  `bson:"NUMER,omitempty" json:"numerator"`
 	MeasureID                string `bson:"measure_id,omitempty" json:"measureId"`
@@ -39,4 +42,87 @@ func FindAllResultsForPatient(db *mgo.Database, patientID string) ([]IndividualR
 	}
 
 	return result, nil
+}
+
+type Population string
+
+const (
+	InitialPatientPopulation Population = "IPP"
+	Denominator                         = "DENOM"
+	Numerator                           = "NUMER"
+	Exception                           = "DENEXCEP"
+	Exclusion                           = "DENEX"
+	Outlier                             = "antinumerator"
+)
+
+type PopulationQuery struct {
+	MeasureID     string     `json:"measureId"`
+	SubID         string     `json:"subId"`
+	EffectiveDate int32      `json:"effectiveDate"`
+	Limit         int        `json:"limit"`
+	Offset        int        `json:"offset"`
+	Population    Population `json:"population"`
+}
+
+func (p PopulationQuery) ToQuery() bson.M {
+	query := bson.M{"value.measure_id": p.MeasureID, "value.effective_date": p.EffectiveDate}
+	if p.SubID != "" {
+		query["value.sub_id"] = p.SubID
+	}
+	populationKey := fmt.Sprintf("value.%s", p.Population)
+	query[populationKey] = bson.M{"$gte": 1}
+	return query
+}
+
+func ParsePopulationQuery(queryParam string) (Population, error) {
+	switch queryParam {
+	case "initialPatientPopulation":
+		return InitialPatientPopulation, nil
+	case "denominator":
+		return Denominator, nil
+	case "numerator":
+		return Numerator, nil
+	case "exception":
+		return Exception, nil
+	case "exclusion":
+		return Exclusion, nil
+	case "outlier":
+		return Outlier, nil
+	}
+	return "", errors.New("Invalid popualtion type")
+}
+
+type PopulationResult struct {
+	Total           int                `json:"total"`
+	PopulationQuery PopulationQuery    `json:"populationQuery"`
+	Patients        []IndividualResult `json:"patients"`
+}
+
+func FindResultsForMeasurePopulation(db *mgo.Database, query PopulationQuery) (*PopulationResult, error) {
+	pr := &PopulationResult{PopulationQuery: query}
+	q := db.C("patient_cache").Find(query.ToQuery())
+	count, err := q.Count()
+	if err != nil {
+		return nil, err
+	}
+	pr.Total = count
+	q.Sort("value.last") // Sort by last name to make sure that offset is consistent between queries
+	q.Skip(query.Offset)
+	if query.Limit != 0 {
+		q.Limit(query.Limit)
+	} else {
+		q.Limit(50)
+	}
+	var wrappedResults []ResultWrapper
+	err = q.All(&wrappedResults)
+	if err != nil {
+		return nil, err
+	}
+	var result []IndividualResult
+	for _, wr := range wrappedResults {
+		result = append(result, wr.IndividualResult)
+	}
+	pr.Patients = result
+
+	return pr, nil
 }

--- a/models/individual_result_test.go
+++ b/models/individual_result_test.go
@@ -24,6 +24,18 @@ func (i *IndividualResultSuite) SetUpSuite(c *C) {
 func (i *IndividualResultSuite) SetUpTest(c *C) {
 	session := i.DBServer.Session()
 	i.Database = session.DB("qme-test")
+	ir := IndividualResult{MeasureID: "abcd", EffectiveDate: 1234, PatientID: "1234", InitialPatientPopulation: 1, Last: "Jones"}
+	id := bson.NewObjectId()
+	rw := &ResultWrapper{ID: id, IndividualResult: ir}
+	i.Database.C("patient_cache").Insert(rw)
+	ir2 := IndividualResult{MeasureID: "efgh", EffectiveDate: 1234, PatientID: "1234", InitialPatientPopulation: 1, Last: "B"}
+	id2 := bson.NewObjectId()
+	rw2 := &ResultWrapper{ID: id2, IndividualResult: ir2}
+	i.Database.C("patient_cache").Insert(rw2)
+	ir3 := IndividualResult{MeasureID: "efgh", EffectiveDate: 1234, PatientID: "5678", InitialPatientPopulation: 1, Denominator: 1, Last: "A"}
+	id3 := bson.NewObjectId()
+	rw3 := &ResultWrapper{ID: id3, IndividualResult: ir3}
+	i.Database.C("patient_cache").Insert(rw3)
 }
 
 func (i *IndividualResultSuite) TearDownTest(c *C) {
@@ -32,15 +44,22 @@ func (i *IndividualResultSuite) TearDownTest(c *C) {
 }
 
 func (i *IndividualResultSuite) TestFindAllResultsForPatient(c *C) {
-	ir := IndividualResult{MeasureID: "abcd", EffectiveDate: 1234, PatientID: "1234", InitialPatientPopulation: 1}
-	id := bson.NewObjectId()
-	rw := &ResultWrapper{ID: id, IndividualResult: ir}
-	i.Database.C("patient_cache").Insert(rw)
-	ir2 := IndividualResult{MeasureID: "efgh", EffectiveDate: 1234, PatientID: "1234", InitialPatientPopulation: 0}
-	id2 := bson.NewObjectId()
-	rw2 := &ResultWrapper{ID: id2, IndividualResult: ir2}
-	i.Database.C("patient_cache").Insert(rw2)
 	results, err := FindAllResultsForPatient(i.Database, "1234")
 	util.CheckErr(err)
 	c.Assert(len(results), Equals, 2)
+}
+
+func (i *IndividualResultSuite) TestFindResultsForMeasurePopulation(c *C) {
+	pq := PopulationQuery{MeasureID: "efgh", EffectiveDate: 1234, Population: InitialPatientPopulation}
+	pr, err := FindResultsForMeasurePopulation(i.Database, pq)
+	util.CheckErr(err)
+	c.Assert(pr.Total, Equals, 2)
+	pt := pr.Patients[0]
+	c.Assert(pt.Last, Equals, "A")
+	pq.Population = Denominator
+	pr, err = FindResultsForMeasurePopulation(i.Database, pq)
+	util.CheckErr(err)
+	c.Assert(pr.Total, Equals, 1)
+	pt = pr.Patients[0]
+	c.Assert(pt.Last, Equals, "A")
 }

--- a/server.go
+++ b/server.go
@@ -49,6 +49,7 @@ func main() {
 		e.GET("/QualityReport/:id", controllers.ShowQualityReportHandler(db))
 		e.POST("/QualityReport", controllers.CreateQualityReportHandler(db))
 		e.GET("/PatientReport/:id", controllers.ShowIndividualResultsForPatientHandler(db))
+		e.GET("/QualityReport/:id/PatientResults", controllers.ShowQualityReportPatientsHandler(db))
 
 		s.Engine.GET("/Measure/:id", controllers.ShowMeasureHandler(db))
 		e.GET("/Measure", controllers.IndexMeasureHandler(db))


### PR DESCRIPTION
You can now get a list of patients in a particular population, like the
numerator from a RESTful endpoint. Supports limit and offset to allow users
to paginate results.
